### PR TITLE
add important dates to nwHacks about section

### DIFF
--- a/components/About.vue
+++ b/components/About.vue
@@ -3,7 +3,9 @@
     <div class="about-content">
       <span class="about-text">About</span>
       <p class="about-p1">
-        Last year we connected over 800 of the brightest developers, engineers, and designers in the Pacific Northwest collaborate and create amazing projects. This year we want to take it to the next level and connect even more hackers across the globe from the comfort of your home. <span class="about-p-bold">nwHacks is going online</span>!
+        Join us at nwHacks on Jan. 9-10th 2021! Apply by Dec. 27th 2020, to participate as a hacker or mentor.
+        <br>
+        Last year we connected over 800 of the brightest developers, engineers, and designers in the Pacific Northwest to collaborate and create amazing projects. This year we want to take it to the next level and connect even more hackers across the globe from the comfort of your home. <span class="about-p-bold">nwHacks is going online</span>!
       </p>
       <p class="about-p2">
         Whether you're a seasoned hacker or a tech newbie, nwHacks welcomes you; just bring an open mind and an insatiable desire to learn, and we’ll take care of the rest. Create a product, learn new skills, and have fun with friends, old and new - all in 24 hours.

--- a/components/About.vue
+++ b/components/About.vue
@@ -180,6 +180,13 @@ $neon-blue: #D0FFFF;
   width: 80%;
 }
 
+@include until($desktop) {
+  .about-content {
+    top: 5%;
+    width: 85%;
+  }
+}
+
 @include until($tablet) {
   .about-container {
     background-image: url('../assets/sprite/png/about__background_mobile.png');
@@ -187,8 +194,7 @@ $neon-blue: #D0FFFF;
   }
 
   .about-content {
-    top: 6%;
-    width: 85%;
+    top: 3%;
   }
 
   .about-panels-content-mobile {
@@ -224,7 +230,7 @@ $neon-blue: #D0FFFF;
     left: 0;
     right: 0;
     position: absolute;
-    top: 10%;
+    top: 14%;
     z-index: 2;
   }
 


### PR DESCRIPTION
## :construction_worker: Changes

New text added to the about section: 
_Join us at nwHacks on Jan. 9-10th 2021! Apply by Dec. 27th 2020, to participate as a hacker or mentor._

## :thought_balloon: Notes

See screenshot, some text is cut off before and after the PR (in mobile). Still readable. 

## :flashlight: Testing Instructions

Open page. Confirm the new text is present. 

![image](https://user-images.githubusercontent.com/47487758/102313090-cfa4f900-3f24-11eb-8133-e060d2f366e8.png)


![image](https://user-images.githubusercontent.com/47487758/102313078-c4ea6400-3f24-11eb-8b51-9d2067bb5961.png)

